### PR TITLE
chore: update Docker configuration and documentation for frontend bui…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,9 @@ TMDB_API_KEY=
 # Optional
 FRONTEND_ORIGIN=http://localhost:8080
 # CORS_ORIGINS=
+
+# Frontend Docker image (Vite) — used at **build** time when you `docker compose build frontend`.
+# The browser loads the SPA from this origin and calls the API here (must be reachable from the user’s machine).
+VITE_API_BASE_URL=http://localhost:3000
+# VITE_APP_NAME=CinéConnect
+# VITE_TMDB_IMAGE_BASE_URL=https://image.tmdb.org/t/p

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -27,9 +27,13 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./apps/frontend/Dockerfile 
+          file: ./apps/frontend/Dockerfile
           push: true
           tags: ghcr.io/${{ github.repository }}/frontend:latest
+          build-args: |
+            VITE_API_BASE_URL=${{ vars.VITE_API_BASE_URL || 'http://localhost:3000' }}
+            VITE_APP_NAME=${{ vars.VITE_APP_NAME || 'CinéConnect' }}
+            VITE_TMDB_IMAGE_BASE_URL=${{ vars.VITE_TMDB_IMAGE_BASE_URL || 'https://image.tmdb.org/t/p' }}
 
       - name: Build and Push Backend Image
         uses: docker/build-push-action@v5

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ pnpm lint
 pnpm tsc -b
 ```
 
+## Docker (frontend build)
+
+The frontend container is a static nginx bundle. **`VITE_*` variables are applied at image build time** (not when the container starts). For `docker compose`, set `VITE_API_BASE_URL` in the repo root `.env` — see `.env.example`. Rebuild after changing them: `docker compose build frontend`.
+
+Details: `apps/frontend/README.md` (Docker & Vite).
+
 ## Backend environment
 
 See `apps/backend/.env.example`. In **production**, `JWT_SECRET` is required and must not be the test default; the app will fail to start if it is missing or insecure. In test, a fallback is allowed so tests can run without setting it.

--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -1,3 +1,6 @@
 # Backend API base URL (no trailing slash). Backend default port is 3000.
+# Docker: for compose builds, also set VITE_* in repo root .env (see root .env.example).
 VITE_API_BASE_URL=http://localhost:3000
-VITE_APP_NAME=CineConnect
+VITE_APP_NAME=CinéConnect
+# Optional TMDB CDN base (defaults in code if omitted)
+# VITE_TMDB_IMAGE_BASE_URL=https://image.tmdb.org/t/p

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -14,6 +14,15 @@ COPY packages ./packages
 
 RUN pnpm install --frozen-lockfile
 
+# Vite inlines `import.meta.env.VITE_*` at build time — must be set here, not at nginx runtime.
+ARG VITE_API_BASE_URL=http://localhost:3000
+ARG VITE_APP_NAME=CinéConnect
+# Optional TMDB image CDN base (must match `utils.ts` default if unchanged)
+ARG VITE_TMDB_IMAGE_BASE_URL=https://image.tmdb.org/t/p
+ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
+ENV VITE_APP_NAME=${VITE_APP_NAME}
+ENV VITE_TMDB_IMAGE_BASE_URL=${VITE_TMDB_IMAGE_BASE_URL}
+
 RUN pnpm run build --filter=frontend
 
 FROM nginx:stable-alpine

--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -1,4 +1,43 @@
-# React + TypeScript + Vite
+# CinéConnect frontend (React + TypeScript + Vite)
+
+## Docker image and `VITE_*` build arguments
+
+The production image (`apps/frontend/Dockerfile`) runs `pnpm build` with environment variables **baked in by Vite**. Nginx only serves static files; it does **not** inject API URLs at runtime.
+
+| Build arg / env | Default | Purpose |
+|-----------------|---------|---------|
+| `VITE_API_BASE_URL` | `http://localhost:3000` | Backend origin (no trailing slash). Must be reachable from the **browser**. |
+| `VITE_APP_NAME` | `CinéConnect` | Optional branding (reserved for future use). |
+| `VITE_TMDB_IMAGE_BASE_URL` | `https://image.tmdb.org/t/p` | TMDB poster base URL. |
+
+**docker compose** (from monorepo root): add `VITE_API_BASE_URL` to root `.env` (see `../../.env.example`). Compose passes it as a build arg. Then:
+
+```bash
+docker compose build frontend
+docker compose up
+```
+
+**Manual image build:**
+
+```bash
+docker build -f apps/frontend/Dockerfile --build-arg VITE_API_BASE_URL=https://api.example.com -t cine-frontend ..
+```
+
+(context must be monorepo root because the Dockerfile copies workspace files.)
+
+### Smoke-test
+
+1. Start stack: `docker compose up` (backend on `3000`, frontend on `8080`).  
+2. Open `http://localhost:8080`.  
+3. In DevTools → Network, confirm XHR/fetch targets your configured API host (`/api/v1/...`).
+
+### CI (GitHub Actions)
+
+Workflow `.github/workflows/docker-deploy.yml` passes `VITE_API_BASE_URL` from repository **Variables** (`vars.VITE_API_BASE_URL`). Set that variable in the repo settings for production deploys (public API URL).
+
+---
+
+## React + TypeScript + Vite (template)
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -56,15 +56,19 @@ services:
     networks:
       - cineconnect-network
 
+  # VITE_* vars are baked in at image build time. Set VITE_API_BASE_URL in root .env (see .env.example)
+  # or: docker compose build --build-arg VITE_API_BASE_URL=https://api.example.com frontend
   frontend:
     build:
       context: .
       dockerfile: apps/frontend/Dockerfile
+      args:
+        VITE_API_BASE_URL: ${VITE_API_BASE_URL:-http://localhost:3000}
+        VITE_APP_NAME: ${VITE_APP_NAME:-CinéConnect}
+        VITE_TMDB_IMAGE_BASE_URL: ${VITE_TMDB_IMAGE_BASE_URL:-https://image.tmdb.org/t/p}
     container_name: cine-frontend
     ports:
       - "8080:80"
-    env_file:
-      - ./apps/frontend/.env
     depends_on:
       backend:
         condition: service_started


### PR DESCRIPTION
…ld arguments

- Added VITE_API_BASE_URL, VITE_APP_NAME, and VITE_TMDB_IMAGE_BASE_URL as build arguments in Dockerfile and docker-compose.yaml.
- Updated .env.example and frontend README.md to reflect new environment variable usage for Docker builds.
- Clarified that VITE_* variables are set at build time, not runtime, in the frontend documentation.