### PR TITLE
feat: add Continue Watching section and mini-player components

### DIFF
--- a/apps/frontend/src/components/glass/ContinueWatchingSection.tsx
+++ b/apps/frontend/src/components/glass/ContinueWatchingSection.tsx
@@ -3,47 +3,11 @@ import { Heart, PauseCircle } from "lucide-react";
 
 import { navLinkOutlineClass } from "@/lib/glass-ui";
 import { cn, getMovieImageUrl } from "@/lib/utils";
+import { CONTINUE_WATCHING_STUB, type ContinueWatchingItem } from "./continueWatchingStub";
 import { GlassPanel } from "./GlassPanel";
 import { PosterCard } from "./PosterCard";
 import { PrimaryButton } from "./PrimaryButton";
 import { ProgressBar } from "./ProgressBar";
-
-export type ContinueWatchingItem = {
-  id: number;
-  title: string;
-  posterPath: string;
-  progress: number;
-  durationLabel: string;
-  remainingLabel: string;
-};
-
-// UI stub (#315): mocked continue-watching data until playback progress is available from API.
-export const CONTINUE_WATCHING_STUB: ContinueWatchingItem[] = [
-  {
-    id: 550,
-    title: "Fight Club",
-    posterPath: "/pB8BM7pdSp6B6Ih7QZ4DrQ3PmJK.jpg",
-    progress: 42,
-    durationLabel: "2h 19m",
-    remainingLabel: "1h 20m restantes",
-  },
-  {
-    id: 278,
-    title: "The Shawshank Redemption",
-    posterPath: "/9cqNxx0GxF0bflZmeSMuL5tnGzr.jpg",
-    progress: 68,
-    durationLabel: "2h 22m",
-    remainingLabel: "45m restantes",
-  },
-  {
-    id: 680,
-    title: "Pulp Fiction",
-    posterPath: "/d5iIlFn5s0ImszYzBPb8JPIfbXD.jpg",
-    progress: 23,
-    durationLabel: "2h 34m",
-    remainingLabel: "1h 58m restantes",
-  },
-];
 
 type ContinueWatchingSectionProps = {
   items?: ContinueWatchingItem[];
@@ -109,7 +73,6 @@ export function MiniPlayerTile({ items = CONTINUE_WATCHING_STUB }: ContinueWatch
         <h2 className="text-lg font-semibold text-ink">Mini-player</h2>
       </div>
       <p className="text-xs text-ink-muted">
-         (sans player réel).
       </p>
       <div className="rounded-2xl border border-[var(--glass-border)] bg-[var(--glass-bg)] p-3">
         <div className="flex items-start gap-3">

--- a/apps/frontend/src/components/glass/ContinueWatchingSection.tsx
+++ b/apps/frontend/src/components/glass/ContinueWatchingSection.tsx
@@ -1,0 +1,157 @@
+import { Link } from "@tanstack/react-router";
+import { Heart, PauseCircle } from "lucide-react";
+
+import { navLinkOutlineClass } from "@/lib/glass-ui";
+import { cn, getMovieImageUrl } from "@/lib/utils";
+import { GlassPanel } from "./GlassPanel";
+import { PosterCard } from "./PosterCard";
+import { PrimaryButton } from "./PrimaryButton";
+import { ProgressBar } from "./ProgressBar";
+
+export type ContinueWatchingItem = {
+  id: number;
+  title: string;
+  posterPath: string;
+  progress: number;
+  durationLabel: string;
+  remainingLabel: string;
+};
+
+// UI stub (#315): mocked continue-watching data until playback progress is available from API.
+export const CONTINUE_WATCHING_STUB: ContinueWatchingItem[] = [
+  {
+    id: 550,
+    title: "Fight Club",
+    posterPath: "/pB8BM7pdSp6B6Ih7QZ4DrQ3PmJK.jpg",
+    progress: 42,
+    durationLabel: "2h 19m",
+    remainingLabel: "1h 20m restantes",
+  },
+  {
+    id: 278,
+    title: "The Shawshank Redemption",
+    posterPath: "/9cqNxx0GxF0bflZmeSMuL5tnGzr.jpg",
+    progress: 68,
+    durationLabel: "2h 22m",
+    remainingLabel: "45m restantes",
+  },
+  {
+    id: 680,
+    title: "Pulp Fiction",
+    posterPath: "/d5iIlFn5s0ImszYzBPb8JPIfbXD.jpg",
+    progress: 23,
+    durationLabel: "2h 34m",
+    remainingLabel: "1h 58m restantes",
+  },
+];
+
+type ContinueWatchingSectionProps = {
+  items?: ContinueWatchingItem[];
+};
+
+/**
+ * Milestone D.9 (issue #315): UI-only continue-watching row + mini-player tile.
+ * Replace `items` with API-backed progress data when playback endpoints are available.
+ */
+export function ContinueWatchingRow({
+  items = CONTINUE_WATCHING_STUB,
+}: ContinueWatchingSectionProps) {
+  if (items.length === 0) return null;
+
+  return (
+    <GlassPanel className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Heart className="h-5 w-5 text-accent-red" aria-hidden />
+          <h2 className="text-lg font-semibold text-ink">Continue watching</h2>
+        </div>
+        <Link to="/watchlist" className={cn(navLinkOutlineClass, "px-3 py-1.5 text-xs")}>
+          Voir la liste
+        </Link>
+      </div>
+      <p className="text-xs text-ink-muted">
+        Stub UI (#315) en attendant les données de progression depuis l&apos;API.
+      </p>
+      <div className="-mx-1 flex snap-x gap-4 overflow-x-auto px-1 pb-2">
+        {items.map((item) => (
+          <Link
+            key={item.id}
+            to="/movie/$movieId"
+            params={{ movieId: String(item.id) }}
+            className="block min-w-[190px] max-w-[220px] shrink-0 rounded-2xl focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-red focus-visible:ring-offset-2 focus-visible:ring-offset-app-base"
+          >
+            <div className="space-y-2">
+              <PosterCard className="max-w-none" title={item.title} posterPath={item.posterPath} />
+              <div className="space-y-1">
+                <div className="flex items-center justify-between text-[11px] text-ink-muted">
+                  <span>{item.durationLabel}</span>
+                  <span>{item.progress}%</span>
+                </div>
+                <ProgressBar value={item.progress} label={`Progression de lecture pour ${item.title}`} />
+                <p className="text-[11px] text-ink-secondary">{item.remainingLabel}</p>
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </GlassPanel>
+  );
+}
+
+export function MiniPlayerTile({ items = CONTINUE_WATCHING_STUB }: ContinueWatchingSectionProps) {
+  if (items.length === 0) return null;
+  const miniPlayerItem = items[0];
+
+  return (
+    <GlassPanel className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Heart className="h-5 w-5 text-accent-red" aria-hidden />
+        <h2 className="text-lg font-semibold text-ink">Mini-player</h2>
+      </div>
+      <p className="text-xs text-ink-muted">
+         (sans player réel).
+      </p>
+      <div className="rounded-2xl border border-[var(--glass-border)] bg-[var(--glass-bg)] p-3">
+        <div className="flex items-start gap-3">
+          <img
+            src={getMovieImageUrl(miniPlayerItem.posterPath, "w185")}
+            alt=""
+            className="h-16 w-12 shrink-0 rounded-lg object-cover"
+          />
+          <div className="min-w-0 flex-1 space-y-2">
+            <p className="truncate text-sm font-semibold text-ink">{miniPlayerItem.title}</p>
+            <div className="flex items-center justify-between text-[11px] text-ink-muted">
+              <span>{miniPlayerItem.durationLabel}</span>
+              <span>{miniPlayerItem.progress}%</span>
+            </div>
+            <ProgressBar
+              value={miniPlayerItem.progress}
+              label={`Progression mini-player pour ${miniPlayerItem.title}`}
+            />
+            <p className="text-[11px] text-ink-secondary">{miniPlayerItem.remainingLabel}</p>
+          </div>
+        </div>
+        <div className="mt-3 flex gap-2">
+          <PrimaryButton
+            asChild
+            icon={<PauseCircle className="h-4 w-4" aria-hidden />}
+            className="w-full justify-center"
+          >
+            <Link to="/movie/$movieId" params={{ movieId: String(miniPlayerItem.id) }}>
+              Reprendre
+            </Link>
+          </PrimaryButton>
+        </div>
+      </div>
+    </GlassPanel>
+  );
+}
+
+export function ContinueWatchingSection(props: ContinueWatchingSectionProps) {
+  return (
+    <>
+      <ContinueWatchingRow {...props} />
+      <MiniPlayerTile {...props} />
+    </>
+  );
+}

--- a/apps/frontend/src/components/glass/continueWatchingStub.ts
+++ b/apps/frontend/src/components/glass/continueWatchingStub.ts
@@ -1,0 +1,37 @@
+// UI stub (#315): mocked continue-watching data until playback progress is available from API.
+
+export type ContinueWatchingItem = {
+  id: number;
+  title: string;
+  posterPath: string;
+  progress: number;
+  durationLabel: string;
+  remainingLabel: string;
+};
+
+export const CONTINUE_WATCHING_STUB: ContinueWatchingItem[] = [
+  {
+    id: 550,
+    title: "Fight Club",
+    posterPath: "/pB8BM7pdSp6B6Ih7QZ4DrQ3PmJK.jpg",
+    progress: 42,
+    durationLabel: "2h 19m",
+    remainingLabel: "1h 20m restantes",
+  },
+  {
+    id: 278,
+    title: "The Shawshank Redemption",
+    posterPath: "/9cqNxx0GxF0bflZmeSMuL5tnGzr.jpg",
+    progress: 68,
+    durationLabel: "2h 22m",
+    remainingLabel: "45m restantes",
+  },
+  {
+    id: 680,
+    title: "Pulp Fiction",
+    posterPath: "/d5iIlFn5s0ImszYzBPb8JPIfbXD.jpg",
+    progress: 23,
+    durationLabel: "2h 34m",
+    remainingLabel: "1h 58m restantes",
+  },
+];

--- a/apps/frontend/src/components/glass/index.ts
+++ b/apps/frontend/src/components/glass/index.ts
@@ -4,10 +4,12 @@ export { PrimaryButton, type PrimaryButtonProps } from "./PrimaryButton"
 export { PosterCard, type PosterCardProps } from "./PosterCard"
 export { ProgressBar, type ProgressBarProps } from "./ProgressBar"
 export {
+  CONTINUE_WATCHING_STUB,
+  type ContinueWatchingItem,
+} from "./continueWatchingStub"
+export {
   ContinueWatchingRow,
   MiniPlayerTile,
   ContinueWatchingSection,
-  CONTINUE_WATCHING_STUB,
-  type ContinueWatchingItem,
 } from "./ContinueWatchingSection"
 export { ToggleRow, type ToggleRowProps } from "./ToggleRow"

--- a/apps/frontend/src/components/glass/index.ts
+++ b/apps/frontend/src/components/glass/index.ts
@@ -3,4 +3,11 @@ export { PillTag, type PillTagProps } from "./PillTag"
 export { PrimaryButton, type PrimaryButtonProps } from "./PrimaryButton"
 export { PosterCard, type PosterCardProps } from "./PosterCard"
 export { ProgressBar, type ProgressBarProps } from "./ProgressBar"
+export {
+  ContinueWatchingRow,
+  MiniPlayerTile,
+  ContinueWatchingSection,
+  CONTINUE_WATCHING_STUB,
+  type ContinueWatchingItem,
+} from "./ContinueWatchingSection"
 export { ToggleRow, type ToggleRowProps } from "./ToggleRow"

--- a/apps/frontend/src/routes/index.tsx
+++ b/apps/frontend/src/routes/index.tsx
@@ -3,7 +3,6 @@ import { MOVIE_GENRES } from "@cine-connect/shared";
 import {
   Clapperboard,
   Compass,
-  Heart,
   Loader2,
   Play,
   Search,
@@ -11,7 +10,7 @@ import {
 } from "lucide-react";
 
 import bgImage from "../../image/BackGround.png";
-import { GlassPanel, PillTag, PosterCard, PrimaryButton, ProgressBar } from "@/components/glass";
+import { ContinueWatchingRow, GlassPanel, MiniPlayerTile, PillTag, PosterCard, PrimaryButton } from "@/components/glass";
 import { useAuth } from "@/hooks/useAuth";
 import { useMovieList } from "@/hooks/useMovies";
 import { navLinkOutlineClass } from "@/lib/glass-ui";
@@ -162,26 +161,11 @@ function AuthenticatedHome() {
         <section className="min-w-0 space-y-6">
           <MovieRow title="Trending maintenant" items={trendingRow} />
           <MovieRow title="Mieux notés en tendance" items={topRatedRow} />
-
-          <GlassPanel className="space-y-4">
-            <div className="flex items-center gap-2">
-              <Heart className="h-5 w-5 text-accent-red" aria-hidden />
-              <h2 className="text-lg font-semibold text-ink">Continue watching</h2>
-            </div>
-            <p className="text-sm text-ink-secondary">
-              Placeholder en attendant les données de reprise de lecture.
-            </p>
-            <div className="space-y-2">
-              <div className="flex items-center justify-between text-xs text-ink-muted">
-                <span>The Last Frontier</span>
-                <span>42%</span>
-              </div>
-              <ProgressBar value={42} />
-            </div>
-          </GlassPanel>
+          <ContinueWatchingRow />
         </section>
 
         <aside className="space-y-6">
+          <MiniPlayerTile />
           <GlassPanel className="space-y-4">
             <div className="flex items-center gap-2">
               <Compass className="h-5 w-5 text-accent-red" aria-hidden />


### PR DESCRIPTION
- Introduced `ContinueWatchingRow` and `MiniPlayerTile` components to display a continue-watching feature with stub data.
- Updated the `index.ts` file to export new components for use in other parts of the application.
- Integrated the new components into the home route, replacing the previous placeholder UI.