### PR TITLE
docs: update JWT_SECRET requirements in README and validation logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The same checks are mirrored as `HEALTHCHECK` in `apps/backend/Dockerfile` and `
 
 ## Backend environment
 
-See `apps/backend/.env.example`. In **production**, `JWT_SECRET` is required and must not be the test default; the app will fail to start if it is missing or insecure. In test, a fallback is allowed so tests can run without setting it.
+See `apps/backend/.env.example`. `JWT_SECRET` is **always** required; there is no hardcoded fallback. In **production** it must be at least 32 characters or the app will not start. Tests use `apps/backend/.env.test` (or CI env) to supply it.
 
 ### Database seed
 

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -90,7 +90,7 @@ The API uses [Helmet](https://helmetjs.github.io/) early in the Express stack (`
 ## Environment
 
 - `DATABASE_URL` — PostgreSQL connection string.
-- `JWT_SECRET` — Secret for signing JWTs (required when `NODE_ENV` !== `"test"`).
+- `JWT_SECRET` — Secret for signing JWTs (always required; at least 32 characters when `NODE_ENV` is `production`).
 - `TMDB_API_KEY` — For movie data (required when not in test).
 - `PORT` — Server port (default `3000`).
 - `FRONTEND_ORIGIN` or `CORS_ORIGINS` — Allowed origins for REST and Socket.io.

--- a/apps/backend/src/config/db.ts
+++ b/apps/backend/src/config/db.ts
@@ -6,40 +6,38 @@ import * as schema from '../db/schema';
 
 dotenv.config();
 
-const TEST_JWT_SECRET = 'fixed_test_secret_123';
+const PRODUCTION_JWT_SECRET_MIN_LENGTH = 32;
 
 /**
  * Validates that required environment variables are set.
  * Call early at bootstrap (e.g. in index.ts after dotenv.config()).
  * - DATABASE_URL: always required.
- * - JWT_SECRET: required when NODE_ENV is not "test"; in production must not be the test value.
+ * - JWT_SECRET: always required (set in apps/backend/.env.test for Vitest). No hardcoded fallback.
  * - TMDB_API_KEY: required when NODE_ENV is not "test" (movie/TMDB routes depend on it).
  */
 export function validateEnv(): void {
-  if (!process.env.DATABASE_URL) {
+  if (!process.env.DATABASE_URL?.trim()) {
     throw new Error('DATABASE_URL environment variable is required');
   }
 
-  if (process.env.NODE_ENV === 'test') {
-    return; // JWT_SECRET and TMDB_API_KEY fallbacks / optional in test
-  }
-
-  if (!process.env.JWT_SECRET || process.env.JWT_SECRET.trim() === '') {
-    throw new Error(
-      'JWT_SECRET environment variable is required when NODE_ENV is not "test"'
-    );
+  if (!process.env.JWT_SECRET?.trim()) {
+    throw new Error('JWT_SECRET environment variable is required');
   }
 
   if (
     process.env.NODE_ENV === 'production' &&
-    process.env.JWT_SECRET === TEST_JWT_SECRET
+    process.env.JWT_SECRET.length < PRODUCTION_JWT_SECRET_MIN_LENGTH
   ) {
     throw new Error(
-      'JWT_SECRET must not be the test value in production. Set a strong secret in production.'
+      `JWT_SECRET must be at least ${PRODUCTION_JWT_SECRET_MIN_LENGTH} characters in production`
     );
   }
 
-  if (!process.env.TMDB_API_KEY || process.env.TMDB_API_KEY.trim() === '') {
+  if (process.env.NODE_ENV === 'test') {
+    return;
+  }
+
+  if (!process.env.TMDB_API_KEY?.trim()) {
     throw new Error(
       'TMDB_API_KEY environment variable is required when NODE_ENV is not "test" (movie routes depend on it)'
     );
@@ -47,15 +45,11 @@ export function validateEnv(): void {
 }
 
 /**
- * Returns the JWT secret. Use this instead of process.env.JWT_SECRET.
- * In test, falls back to a fixed value so tests can run without setting JWT_SECRET.
- * Otherwise returns the validated JWT_SECRET (validateEnv must have been called at startup).
+ * Returns the JWT secret. Use this instead of reading process.env.JWT_SECRET directly.
+ * validateEnv() must run at startup before any JWT is signed or verified.
  */
 export function getJwtSecret(): string {
-  if (process.env.NODE_ENV === 'test') {
-    return process.env.JWT_SECRET || TEST_JWT_SECRET;
-  }
-  return process.env.JWT_SECRET!;
+  return process.env.JWT_SECRET!.trim();
 }
 
 function getConnectionString(): string {


### PR DESCRIPTION
- Clarified that `JWT_SECRET` is always required and must be at least 32 characters in production.
- Removed hardcoded fallback for `JWT_SECRET` in the environment validation logic.
- Updated documentation in both the main README and backend README to reflect these changes.