### PR TITLE
feat(frontend): enforce VITE_API_BASE_URL requirement for builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,4 +33,9 @@ jobs:
         run: pnpm turbo run lint
 
       - name: Build Projects
+        env:
+          # Required for `vite build` (no hardcoded production fallback in source).
+          VITE_API_BASE_URL: http://localhost:3000
+          VITE_APP_NAME: CinéConnect
+          VITE_TMDB_IMAGE_BASE_URL: https://image.tmdb.org/t/p
         run: pnpm turbo run build --filter='!@cine-connect/shared'

--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -11,6 +11,7 @@
 # VITE_API_BASE_URL=http://localhost:3000
 
 # --- Production: full API origin (HTTPS); cookies use Secure in NODE_ENV=production on the API ---
+# Required for `pnpm build` / `vite build` (no hardcoded fallback). Use .env.production or export.
 # VITE_API_BASE_URL=https://api.yourdomain.com
 
 VITE_APP_NAME=CinéConnect

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -15,7 +15,8 @@ COPY packages ./packages
 RUN pnpm install --frozen-lockfile
 
 # Vite inlines `import.meta.env.VITE_*` at build time — must be set here, not at nginx runtime.
-ARG VITE_API_BASE_URL=http://localhost:3000
+# No default: production bundles must not ship with an implicit API URL (see issue #341).
+ARG VITE_API_BASE_URL
 ARG VITE_APP_NAME=CinéConnect
 # Optional TMDB image CDN base (must match `utils.ts` default if unchanged)
 ARG VITE_TMDB_IMAGE_BASE_URL=https://image.tmdb.org/t/p

--- a/apps/frontend/src/lib/api-origin.ts
+++ b/apps/frontend/src/lib/api-origin.ts
@@ -10,7 +10,9 @@ export function resolveApiBaseUrl(): string {
   if (import.meta.env.DEV) {
     return "";
   }
-  return "http://localhost:3000";
+  throw new Error(
+    "VITE_API_BASE_URL was not set at build time. Rebuild the app with VITE_API_BASE_URL defined (see apps/frontend/README.md)."
+  );
 }
 
 export const ApiClientConfig = {

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -8,8 +8,17 @@ import { fileURLToPath } from "url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, __dirname, "");
+export default defineConfig(({ command, mode }) => {
+  // Use the VITE_ prefix only (default). Passing "" would match every env key and hide a missing VITE_API_BASE_URL.
+  const env = loadEnv(mode, __dirname, "VITE_");
+  if (command === "build") {
+    const api = String(env.VITE_API_BASE_URL ?? "").trim();
+    if (!api) {
+      throw new Error(
+        "VITE_API_BASE_URL must be set when running `vite build` (CI, Docker, or local: export it or use apps/frontend/.env.production). See apps/frontend/README.md."
+      );
+    }
+  }
   // Prefer 127.0.0.1 so the proxy matches a backend bound to IPv4 (avoids some localhost → ::1 mismatches).
   const proxyTarget = env.VITE_API_PROXY_TARGET || "http://127.0.0.1:3000";
 


### PR DESCRIPTION
- Updated CI configuration to set environment variables for Vite builds.
- Modified Dockerfile to remove default API URL, ensuring production builds do not include hardcoded values.
- Enhanced vite.config.ts to throw an error if VITE_API_BASE_URL is not defined during the build process.
- Updated api-origin.ts to reflect the new requirement for VITE_API_BASE_URL, improving error handling for missing configurations.