### PR TITLE
fix: update docker-compose.yaml to change frontend port mapping

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -100,7 +100,7 @@ services:
         NGINX_API_UPSTREAM: ${NGINX_API_UPSTREAM:-http://backend:3000}
     container_name: cine-frontend
     ports:
-      - "8080:80"
+      - "80:80"
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://127.0.0.1/ >/dev/null || exit 1"]
       interval: 15s


### PR DESCRIPTION
- Modified the port mapping for the cine-frontend service from "8080:80" to "80:80" to align with standard HTTP port usage.