### PR TITLE
fix: add volume mapping for SSL certificates in docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -101,6 +101,8 @@ services:
         VITE_TMDB_IMAGE_BASE_URL: ${VITE_TMDB_IMAGE_BASE_URL:-https://image.tmdb.org/t/p}
         NGINX_API_UPSTREAM: ${NGINX_API_UPSTREAM:-http://backend:3000}
     container_name: cine-frontend
+    volumes:
+      - /etc/letsencrypt:/etc/letsencrypt:ro
     ports:
       - "80:80"
     healthcheck:


### PR DESCRIPTION
- Added a read-only volume mapping for Let's Encrypt certificates to the cine-frontend service, enhancing security for SSL handling.