### PR TITLE
fix: update NGINX configuration for uploads handling

### DIFF
--- a/apps/frontend/nginx/default.conf
+++ b/apps/frontend/nginx/default.conf
@@ -57,13 +57,15 @@ server {
         proxy_read_timeout 60s;
     }
 
-    location /uploads/ {
+    location ^~ /uploads/ {
         proxy_pass __NGINX_API_UPSTREAM__/uploads/;
         proxy_http_version 1.1;
         proxy_ssl_server_name on;
         proxy_set_header Host __NGINX_API_HOST__;
         proxy_set_header X-Forwarded-Proto $forwarded_proto;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        expires -1;
     }
 
     location /socket.io/ {


### PR DESCRIPTION
- Changed location directive for /uploads/ to use a prefix match.
- Added cache control by setting expires to -1 for uploads, ensuring no caching of uploaded files.